### PR TITLE
Enable Next button on Install step even if Digma Engine is not installed

### DIFF
--- a/src/components/InstallationWizard/InstallStep/index.tsx
+++ b/src/components/InstallationWizard/InstallStep/index.tsx
@@ -360,9 +360,7 @@ export const InstallStep = (props: InstallStepProps) => {
           />
           <s.CommonContentContainer>
             {(isAutoInstallationFinished ||
-              (!isAutoInstallationFlow &&
-                config.isDigmaEngineInstalled &&
-                !isEngineOperationInProgress)) && (
+              (!isAutoInstallationFlow && !isEngineOperationInProgress)) && (
               <MainButton onClick={handleNextButtonClick}>Next</MainButton>
             )}
           </s.CommonContentContainer>


### PR DESCRIPTION
Enable the Next button on the Install step (not the first launch) even if Digma Engine is not installed