### PR TITLE
Fixed trace navigation

### DIFF
--- a/src/components/Insights/TopUsageInsight/index.tsx
+++ b/src/components/Insights/TopUsageInsight/index.tsx
@@ -30,7 +30,7 @@ export const TopUsageInsight = (props: TopUsageInsightProps) => {
   const handleTraceButtonClick = (
     trace: Trace,
     insightType: InsightType,
-    spanCodeObjectId: string
+    spanCodeObjectId?: string
   ) => {
     props.onTraceButtonClick(trace, insightType, spanCodeObjectId);
   };
@@ -94,7 +94,7 @@ export const TopUsageInsight = (props: TopUsageInsightProps) => {
                           id: traceId
                         },
                         props.insight.type,
-                        flow.firstService.spanCodeObjectId
+                        props.insight.spanInfo?.spanCodeObjectId
                       )
                     }
                   >

--- a/src/components/Insights/TopUsageInsight/types.ts
+++ b/src/components/Insights/TopUsageInsight/types.ts
@@ -10,6 +10,6 @@ export interface TopUsageInsightProps extends InsightProps {
   onTraceButtonClick: (
     trace: Trace,
     insightType: InsightType,
-    spanCodeObjectId: string
+    spanCodeObjectId?: string
   ) => void;
 }


### PR DESCRIPTION
The trace button from the "Top Usage" insight should navigate to the current span.